### PR TITLE
Возможность кешировать свечи

### DIFF
--- a/core/src/main/java/ru/tinkoff/invest/openapi/models/market/Candle.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/models/market/Candle.java
@@ -27,30 +27,35 @@ public final class Candle {
     /**
      * Цена открытия.
      */
+    @JsonProperty(value = "o")
     @NotNull
     public final BigDecimal openPrice;
 
     /**
      * Цена закрытия.
      */
+    @JsonProperty(value = "c")
     @NotNull
     public final BigDecimal closePrice;
 
     /**
      * Максимальная цена.
      */
+    @JsonProperty(value = "h")
     @NotNull
     public final BigDecimal highestPrice;
 
     /**
      * Минимальная цена.
      */
+    @JsonProperty(value = "l")
     @NotNull
     public final BigDecimal lowestPrice;
 
     /**
      * Объём торгов.
      */
+    @JsonProperty(value = "v")
     @NotNull
     public final BigDecimal tradesValue;
 


### PR DESCRIPTION
Хотелось бы иметь возможность кешировать инструменты дабы не запрашивать весь список каждый запуск, но из за того что свечи в конструкторе ожидают сокращенные имена, а при сериализации записывает их с полными именами, то такой возможности, без дополнительных костылей или модификации sdk, нет.