### PR TITLE
Завершение работы пула тредов у OkHttpClinet

### DIFF
--- a/sdk-java8/src/main/java/ru/tinkoff/invest/openapi/okhttp/StreamingContextImpl.java
+++ b/sdk-java8/src/main/java/ru/tinkoff/invest/openapi/okhttp/StreamingContextImpl.java
@@ -88,6 +88,7 @@ class StreamingContextImpl implements StreamingContext {
         for (final WebSocket ws : this.wsClients) {
             ws.close(1000, null);
         }
+        client.dispatcher().executorService().shutdown();
     }
 
     public void restore(@NotNull final StreamingApiListener listener) throws Exception {


### PR DESCRIPTION
Сейчас не происходит корректного завершения программы из за висящих потоков созданных OkHttpClinet'ом.

Уверен, что абсолютно не верно делать это именно в методе close у StreamingContext'а, но раз уж он и так нарушает состояние StreamingContext, то пожалуй, чтобы не вносить большие изменения пул реквестом, это отличная мера