### PR TITLE
Рефакторинг StreamingApiContext

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,6 +7,7 @@ dependencies {
             [group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.2'],
             [group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: '2.10.2'],
             [group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.10.2'],
+            [group: 'org.reactivestreams', name: 'reactive-streams', version: '1.0.3'],
             [group: 'org.jetbrains', name: 'annotations', version: '13.0'],
     )
 }

--- a/core/src/main/java/ru/tinkoff/invest/openapi/MarketContext.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/MarketContext.java
@@ -6,7 +6,6 @@ import ru.tinkoff.invest.openapi.models.market.*;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 
 /**
  * Интерфейс работы с OpenAPI в части касающейся получения рыночной информации.
@@ -14,45 +13,57 @@ import java.util.function.Consumer;
 public interface MarketContext extends Context {
 
     /**
-     * Получение списка акций, доступных для торговли.
+     * Асинхронное получение списка акций, доступных для торговли.
+     * 
+     * @return Список акций.
      */
     @NotNull
     CompletableFuture<InstrumentsList> getMarketStocks();
 
     /**
-     * Получение списка бондов, доступных для торговли.
+     * Асинхронное получение бондов, доступных для торговли.
+     * 
+     * @return Список облигаций.
      */
     @NotNull
     CompletableFuture<InstrumentsList> getMarketBonds();
 
     /**
-     * Получение списка фондов, доступных для торговли.
+     * Асинхронное получение списка фондов, доступных для торговли.
+     * 
+     * @return Список фондов.
      */
     @NotNull
     CompletableFuture<InstrumentsList> getMarketEtfs();
 
     /**
-     * Получение списка валют, доступных для торговли.
+     * Асинхронное получение списка валют, доступных для торговли.
+     * 
+     * @return Список валют.
      */
     @NotNull
     CompletableFuture<InstrumentsList> getMarketCurrencies();
 
     /**
-     * Получение текущего состояния торгового "стакана".
+     * Асинхронное получение текущего состояния торгового "стакана".
      *
      * @param figi     Идентификатор инструмента.
      * @param depth    Глубина стакана.
+     * 
+     * @return "Стакан" по инструменту или ничего, если инструмент не найден.  
      */
     @NotNull
     CompletableFuture<Optional<Orderbook>> getMarketOrderbook(@NotNull String figi, int depth);
 
     /**
-     * Получение исторических данных по свечам.
+     * Асинхронное получение исторических данных по свечам.
      *
      * @param figi     Идентификатор инструмента.
      * @param from     Начальный момент рассматриваемого отрезка временного интервала.
      * @param to       Конечный момент рассматриваемого отрезка временного интервала.
      * @param interval Разрешающий интервал свечей.
+     * 
+     * @return Данные по свечам инструмента или ничего, если инструмент не найден.
      */
     @NotNull
     CompletableFuture<Optional<HistoricalCandles>> getMarketCandles(@NotNull String figi,
@@ -61,17 +72,21 @@ public interface MarketContext extends Context {
                                                                     @NotNull CandleInterval interval);
 
     /**
-     * Поиск инструментов по тикеру.
+     * Асинхронный поиск инструментов по тикеру.
      *
-     * @param ticker   Искомый тикер.
+     * @param ticker Искомый тикер.
+     * 
+     * @return Список инструментов.
      */
     @NotNull
     CompletableFuture<InstrumentsList> searchMarketInstrumentsByTicker(@NotNull String ticker);
 
     /**
-     * Поиск инструмента по идентификатору.
+     * Асинронный поиск инструмента по идентификатору.
      *
-     * @param figi     Искомый тикер.
+     * @param figi Искомый тикер.
+     * 
+     * @return Найденный инструмент или ничего, если инструмент не найден.
      */
     @NotNull
     CompletableFuture<Optional<Instrument>> searchMarketInstrumentByFigi(@NotNull String figi);

--- a/core/src/main/java/ru/tinkoff/invest/openapi/OpenApi.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/OpenApi.java
@@ -2,11 +2,12 @@ package ru.tinkoff.invest.openapi;
 
 import org.jetbrains.annotations.NotNull;
 
-public interface OpenApi {
+public interface OpenApi extends AutoCloseable {
     @NotNull MarketContext getMarketContext();
     @NotNull OperationsContext getOperationsContext();
     @NotNull OrdersContext getOrdersContext();
     @NotNull PortfolioContext getPortfolioContext();
     @NotNull UserContext getUserContext();
     @NotNull StreamingContext getStreamingContext();
+    boolean hasClosed();
 }

--- a/core/src/main/java/ru/tinkoff/invest/openapi/OpenApiFactoryBase.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/OpenApiFactoryBase.java
@@ -1,13 +1,11 @@
 package ru.tinkoff.invest.openapi;
 
 import org.jetbrains.annotations.NotNull;
-import ru.tinkoff.invest.openapi.models.streaming.StreamingEvent;
-
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
-import java.util.function.Consumer;
+import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -26,12 +24,10 @@ abstract public class OpenApiFactoryBase {
     }
 
     @NotNull
-    abstract public OpenApi createOpenApiClient(@NotNull Consumer<StreamingEvent> streamingEventCallback,
-                                                @NotNull Consumer<Throwable> streamingErrorCallback);
+    abstract public OpenApi createOpenApiClient(@NotNull final Executor executor);
 
     @NotNull
-    abstract public SandboxOpenApi createSandboxOpenApiClient(@NotNull Consumer<StreamingEvent> streamingEventCallback,
-                                                              @NotNull Consumer<Throwable> streamingErrorCallback);
+    abstract public SandboxOpenApi createSandboxOpenApiClient(@NotNull final Executor executor);
 
     /**
      * Извлечение параметров конфигурации.

--- a/core/src/main/java/ru/tinkoff/invest/openapi/OperationsContext.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/OperationsContext.java
@@ -13,12 +13,14 @@ import java.util.concurrent.CompletableFuture;
 public interface OperationsContext extends Context {
 
     /**
-     * Получение списка прошедших операций по заданному инструменту за определённый промежуток времени.
+     * Асинхронное получение списка прошедших операций по заданному инструменту за определённый промежуток времени.
      *
      * @param from Дата/время начала промежутка времени.
      * @param to Дата/время конца промежутка времени.
      * @param figi Идентификатор инструмента.
      * @param brokerAccountId Идентификатор брокерского счёта.
+     * 
+     * @return Список операций.
      */
     @NotNull
     CompletableFuture<OperationsList> getOperations(@NotNull OffsetDateTime from,

--- a/core/src/main/java/ru/tinkoff/invest/openapi/OrdersContext.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/OrdersContext.java
@@ -16,9 +16,11 @@ import java.util.concurrent.CompletableFuture;
 public interface OrdersContext extends Context {
 
     /**
-     * Получение списка активных заявок.
+     * Асинхронное получение списка активных заявок.
      *
      * @param brokerAccountId Идентификатор брокерского счёта.
+     * 
+     * @return Список заявок.
      */
     @NotNull
     CompletableFuture<List<Order>> getOrders(@Nullable String brokerAccountId);
@@ -29,6 +31,8 @@ public interface OrdersContext extends Context {
      * @param figi Идентификатор инструмента.
      * @param limitOrder Параметры отправляемой заявки.
      * @param brokerAccountId Идентификатор брокерского счёта.
+     * 
+     * @return Размещённая заявка.
      */
     @NotNull
     CompletableFuture<PlacedOrder> placeLimitOrder(@NotNull String figi,
@@ -41,6 +45,8 @@ public interface OrdersContext extends Context {
      * @param figi Идентификатор инструмента.
      * @param marketOrder Параметры отправляемой заявки.
      * @param brokerAccountId Идентификатор брокерского счёта.
+     * 
+     * @return Размещённая заявка.
      */
     @NotNull
     CompletableFuture<PlacedOrder> placeMarketOrder(@NotNull String figi,
@@ -52,6 +58,8 @@ public interface OrdersContext extends Context {
      *
      * @param orderId Идентификатор заявки.
      * @param brokerAccountId Идентификатор брокерского счёта.
+     * 
+     * @return Ничего.
      */
     @NotNull
     CompletableFuture<Void> cancelOrder(@NotNull String orderId, @Nullable String brokerAccountId);

--- a/core/src/main/java/ru/tinkoff/invest/openapi/PortfolioContext.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/PortfolioContext.java
@@ -13,17 +13,21 @@ import java.util.concurrent.CompletableFuture;
 public interface PortfolioContext extends Context {
 
     /**
-     * Получение информации по портфелю инструментов.
+     * Асинхронное получение информации по портфелю инструментов.
      *
      * @param brokerAccountId Идентификатор брокерского счёта.
+     * 
+     * @return Портфель инструментов.
      */
     @NotNull
     CompletableFuture<Portfolio> getPortfolio(@Nullable String brokerAccountId);
 
     /**
-     * Получение информации по валютным активам.
+     * Асинхронное получение информации по валютным активам.
      *
      * @param brokerAccountId Идентификатор брокерского счёта.
+     * 
+     * @return Портфель валют.
      */
     @NotNull
     CompletableFuture<PortfolioCurrencies> getPortfolioCurrencies(@Nullable String brokerAccountId);

--- a/core/src/main/java/ru/tinkoff/invest/openapi/SandboxContext.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/SandboxContext.java
@@ -17,6 +17,8 @@ public interface SandboxContext extends Context {
      * Регистрация в системе "песочницы". Проводится один раз для клиента.
      *
      * @param brokerAccountType Тип брокерского счёта.
+     * 
+     * @return Ничего.
      */
     @NotNull
     CompletableFuture<Void> performRegistration(@Nullable BrokerAccountType brokerAccountType);
@@ -26,6 +28,8 @@ public interface SandboxContext extends Context {
      *
      * @param data Жалаемые параметры позиции.
      * @param brokerAccountId Идентификатор брокерского счёта.
+     * 
+     * @return Ничего.
      */
     @NotNull
     CompletableFuture<Void> setCurrencyBalance(@NotNull CurrencyBalance data, @Nullable String brokerAccountId);
@@ -35,6 +39,8 @@ public interface SandboxContext extends Context {
      *
      * @param data Жалаемые параметры позиции.
      * @param brokerAccountId Идентификатор брокерского счёта.
+     * 
+     * @return Ничего.
      */
     @NotNull
     CompletableFuture<Void> setPositionBalance(@NotNull PositionBalance data, @Nullable String brokerAccountId);
@@ -43,6 +49,8 @@ public interface SandboxContext extends Context {
      * Сброс всех установленных значений по активам.
      *
      * @param brokerAccountId Идентификатор брокерского счёта.
+     * 
+     * @return Ничего.
      */
     @NotNull
     CompletableFuture<Void> clearAll(@Nullable String brokerAccountId);

--- a/core/src/main/java/ru/tinkoff/invest/openapi/StreamingContext.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/StreamingContext.java
@@ -1,17 +1,14 @@
 package ru.tinkoff.invest.openapi;
 
 import org.jetbrains.annotations.NotNull;
+import org.reactivestreams.Publisher;
+
 import ru.tinkoff.invest.openapi.models.streaming.StreamingEvent;
 import ru.tinkoff.invest.openapi.models.streaming.StreamingRequest;
 
 public interface StreamingContext {
     void sendRequest(@NotNull StreamingRequest request);
 
-    void close();
-
-    interface StreamingEventHandler {
-        void handleEvent(@NotNull StreamingEvent event);
-
-        void handleError(@NotNull Throwable error);
-    }
+    @NotNull
+    Publisher<StreamingEvent> getEventPublisher(); 
 }

--- a/core/src/main/java/ru/tinkoff/invest/openapi/UserContext.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/UserContext.java
@@ -1,12 +1,10 @@
 package ru.tinkoff.invest.openapi;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import ru.tinkoff.invest.openapi.models.operations.OperationsList;
-import ru.tinkoff.invest.openapi.models.user.AccountsList;
-
-import java.time.OffsetDateTime;
 import java.util.concurrent.CompletableFuture;
+
+import org.jetbrains.annotations.NotNull;
+
+import ru.tinkoff.invest.openapi.models.user.AccountsList;
 
 /**
  * Интерфейс работы с OpenAPI в части касающейся получения информации о клиенте.
@@ -14,7 +12,9 @@ import java.util.concurrent.CompletableFuture;
 public interface UserContext extends Context {
 
     /**
-     * Получение списка брокерских счетов.
+     * Асинхронное получение списка брокерских счетов.
+     * 
+     * @return Список счетов.
      */
     @NotNull
     CompletableFuture<AccountsList> getAccounts();

--- a/core/src/main/java/ru/tinkoff/invest/openapi/exceptions/NotEnoughBalanceException.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/exceptions/NotEnoughBalanceException.java
@@ -7,6 +7,8 @@ import java.util.regex.Pattern;
 
 public class NotEnoughBalanceException extends OpenApiException {
 
+    private static final long serialVersionUID = -4135428712268662987L;
+
     private static Pattern currencyExtractionPattern = Pattern.compile("^.+=(\\w+)$");
 
     private final String currency;

--- a/core/src/main/java/ru/tinkoff/invest/openapi/exceptions/OpenApiException.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/exceptions/OpenApiException.java
@@ -9,6 +9,8 @@ import org.jetbrains.annotations.NotNull;
  */
 public class OpenApiException extends Exception {
 
+    private static final long serialVersionUID = -1549345261742621592L;
+    
     /**
      * Код ошибки в OpenAPI.
      */

--- a/core/src/main/java/ru/tinkoff/invest/openapi/exceptions/OrderAlreadyCancelledException.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/exceptions/OrderAlreadyCancelledException.java
@@ -7,6 +7,8 @@ import java.util.regex.Pattern;
 
 public class OrderAlreadyCancelledException extends OpenApiException {
 
+    private static final long serialVersionUID = -5527556849561779960L;
+
     private static Pattern orderIdExtractionPattern = Pattern.compile("^.+id (.+)$");
 
     private final String orderId;

--- a/core/src/main/java/ru/tinkoff/invest/openapi/exceptions/WrongTokenException.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/exceptions/WrongTokenException.java
@@ -5,6 +5,8 @@ package ru.tinkoff.invest.openapi.exceptions;
  */
 public class WrongTokenException extends OpenApiException {
 
+    private static final long serialVersionUID = -4989718480862810249L;
+
     public static String ACCESS_DENIED_MESSAGE_CODE = "ACCESS_DENIED";
 
     public WrongTokenException() {

--- a/core/src/main/java/ru/tinkoff/invest/openapi/models/MoneyAmount.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/models/MoneyAmount.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jetbrains.annotations.NotNull;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 
 /**
  * Модель денежных средств.

--- a/core/src/main/java/ru/tinkoff/invest/openapi/models/RestResponse.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/models/RestResponse.java
@@ -1,9 +1,8 @@
 package ru.tinkoff.invest.openapi.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.jetbrains.annotations.NotNull;
 
-import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Модель ответа от REST API.

--- a/core/src/main/java/ru/tinkoff/invest/openapi/models/orders/MarketOrder.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/models/orders/MarketOrder.java
@@ -2,8 +2,6 @@ package ru.tinkoff.invest.openapi.models.orders;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.math.BigDecimal;
-
 /**
  * Модель лимитной заявки.
  */

--- a/core/src/main/java/ru/tinkoff/invest/openapi/models/orders/Order.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/models/orders/Order.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jetbrains.annotations.NotNull;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 
 /**
  * Модель биржевой заявки.

--- a/core/src/main/java/ru/tinkoff/invest/openapi/models/sandbox/CurrencyBalance.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/models/sandbox/CurrencyBalance.java
@@ -4,7 +4,6 @@ import org.jetbrains.annotations.NotNull;
 import ru.tinkoff.invest.openapi.models.Currency;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 
 /**
  * Данные для запроса на выставление баланса по валюте.

--- a/core/src/main/java/ru/tinkoff/invest/openapi/models/sandbox/PositionBalance.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/models/sandbox/PositionBalance.java
@@ -3,7 +3,6 @@ package ru.tinkoff.invest.openapi.models.sandbox;
 import org.jetbrains.annotations.NotNull;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 
 /**
  * Данные для запроса на выставление баланса по позиции.

--- a/core/src/main/java/ru/tinkoff/invest/openapi/models/streaming/StreamingEvent.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/models/streaming/StreamingEvent.java
@@ -527,6 +527,8 @@ public abstract class StreamingEvent {
 
     static class StreamingEventDeserializer extends StdDeserializer<StreamingEvent> {
 
+        private static final long serialVersionUID = -4598785717730517692L;
+
         public StreamingEventDeserializer() {
             this(null);
         }

--- a/core/src/main/java/ru/tinkoff/invest/openapi/models/user/AccountsList.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/models/user/AccountsList.java
@@ -3,8 +3,6 @@ package ru.tinkoff.invest.openapi.models.user;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jetbrains.annotations.NotNull;
-import ru.tinkoff.invest.openapi.models.operations.Operation;
-
 import java.util.List;
 
 /**

--- a/core/src/main/java/ru/tinkoff/invest/openapi/models/user/BrokerAccountType.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/models/user/BrokerAccountType.java
@@ -3,7 +3,7 @@ package ru.tinkoff.invest.openapi.models.user;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Перечислние возможных типов операции.
+ * Перечислние возможных типов юрокерских счетов.
  */
 public enum BrokerAccountType {
     @JsonProperty("Tinkoff")

--- a/example/src/main/java/ru/tinkoff/invest/openapi/example/StreamingApiSubscriber.java
+++ b/example/src/main/java/ru/tinkoff/invest/openapi/example/StreamingApiSubscriber.java
@@ -1,0 +1,27 @@
+package ru.tinkoff.invest.openapi.example;
+
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+
+import org.jetbrains.annotations.NotNull;
+import org.reactivestreams.example.unicast.AsyncSubscriber;
+
+import ru.tinkoff.invest.openapi.models.streaming.StreamingEvent;
+
+class StreamingApiSubscriber extends AsyncSubscriber<StreamingEvent> {
+
+    private final Logger logger;
+
+    StreamingApiSubscriber(@NotNull final Logger logger, @NotNull final Executor executor) {
+        super(executor);
+        this.logger = logger;
+    }
+
+    @Override
+    protected boolean whenNext(final StreamingEvent event) {
+        logger.info("Пришло новое событие из Streaming API\n" + event);
+
+        return true;
+    }
+
+}

--- a/sdk-java8/build.gradle
+++ b/sdk-java8/build.gradle
@@ -9,6 +9,7 @@ dependencies {
             [group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.10.2'],
             [group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.3.1'],
             [group: 'org.reactivestreams', name: 'reactive-streams', version: '1.0.3'],
+            [group: 'org.reactivestreams', name: 'reactive-streams-examples', version: '1.0.3'],
             project(':core')
     )
     testCompile group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.5.2'

--- a/sdk-java8/src/main/java/ru/tinkoff/invest/openapi/okhttp/OkHttpOpenApi.java
+++ b/sdk-java8/src/main/java/ru/tinkoff/invest/openapi/okhttp/OkHttpOpenApi.java
@@ -1,70 +1,122 @@
 package ru.tinkoff.invest.openapi.okhttp;
 
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+
 import org.jetbrains.annotations.NotNull;
+
+import okhttp3.OkHttpClient;
 import ru.tinkoff.invest.openapi.*;
 
 public class OkHttpOpenApi implements OpenApi {
 
     @NotNull
-    private final MarketContext marketContext;
+    private final MarketContextImpl marketContext;
     @NotNull
-    private final OperationsContext operationsContext;
+    private final OperationsContextImpl operationsContext;
     @NotNull
-    private final OrdersContext ordersContext;
+    private final OrdersContextImpl ordersContext;
     @NotNull
-    private final PortfolioContext portfolioContext;
+    private final PortfolioContextImpl portfolioContext;
     @NotNull
-    private final UserContext userContext;
+    private final UserContextImpl userContext;
     @NotNull
-    private final StreamingContext streamingContext;
+    private final StreamingContextImpl streamingContext;
+    @NotNull
+    private final OkHttpClient client;
+    private boolean hasClosed;
 
-    OkHttpOpenApi(@NotNull final MarketContext marketContext,
-                  @NotNull final OperationsContext operationsContext,
-                  @NotNull final OrdersContext ordersContext,
-                  @NotNull final PortfolioContext portfolioContext,
-                  @NotNull final UserContext userContext,
-                  @NotNull final StreamingContext streamingContext) {
+    OkHttpOpenApi(@NotNull OkHttpClient client,
+                  @NotNull final MarketContextImpl marketContext,
+                  @NotNull final OperationsContextImpl operationsContext,
+                  @NotNull final OrdersContextImpl ordersContext,
+                  @NotNull final PortfolioContextImpl portfolioContext,
+                  @NotNull final UserContextImpl userContext,
+                  @NotNull final StreamingContextImpl streamingContext) {
+        this.client = client;
         this.marketContext = marketContext;
         this.operationsContext = operationsContext;
         this.ordersContext = ordersContext;
         this.portfolioContext = portfolioContext;
         this.userContext = userContext;
         this.streamingContext = streamingContext;
+        this.hasClosed = false;
+    }
+
+    public static OkHttpOpenApi create(
+        final OkHttpClient client,
+        final String apiUrl,
+        final String streamingUrl,
+        final int streamingParallelism,
+        final String authToken,
+        final Executor executor,
+        final Logger logger
+    ) {
+        final MarketContextImpl marketContext = new MarketContextImpl(client, apiUrl, authToken, logger);
+        final OperationsContextImpl operationsContext = new OperationsContextImpl(client, apiUrl, authToken, logger);
+        final OrdersContextImpl ordersContext = new OrdersContextImpl(client, apiUrl, authToken, logger);
+        final PortfolioContextImpl portfolioContext = new PortfolioContextImpl(client, apiUrl, authToken, logger);
+        final UserContextImpl userContext = new UserContextImpl(client, apiUrl, authToken, logger);
+        final StreamingContextImpl streamingContext = new StreamingContextImpl(client, streamingUrl, authToken, streamingParallelism, logger, executor);
+
+        return new OkHttpOpenApi(
+                client,
+                marketContext,
+                operationsContext,
+                ordersContext,
+                portfolioContext,
+                userContext,
+                streamingContext
+        );
     }
 
     @NotNull
     @Override
     public MarketContext getMarketContext() {
-        return marketContext;
+        return this.marketContext;
     }
 
     @NotNull
     @Override
     public OperationsContext getOperationsContext() {
-        return operationsContext;
+        return this.operationsContext;
     }
 
     @NotNull
     @Override
     public OrdersContext getOrdersContext() {
-        return ordersContext;
+        return this.ordersContext;
     }
 
     @NotNull
     @Override
     public PortfolioContext getPortfolioContext() {
-        return portfolioContext;
+        return this.portfolioContext;
     }
 
     @NotNull
     @Override
     public UserContext getUserContext() {
-        return userContext;
+        return this.userContext;
     }
 
     @NotNull
     @Override
     public StreamingContext getStreamingContext() {
-        return streamingContext;
+        return this.streamingContext;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (!hasClosed) {
+            this.streamingContext.stop();
+            this.client.dispatcher().executorService().shutdown();
+            this.hasClosed = true;
+        }        
+    }
+
+    @Override
+    public boolean hasClosed() {
+        return this.hasClosed;
     }
 }

--- a/sdk-java8/src/main/java/ru/tinkoff/invest/openapi/okhttp/OkHttpOpenApiFactory.java
+++ b/sdk-java8/src/main/java/ru/tinkoff/invest/openapi/okhttp/OkHttpOpenApiFactory.java
@@ -3,10 +3,8 @@ package ru.tinkoff.invest.openapi.okhttp;
 import okhttp3.OkHttpClient;
 import org.jetbrains.annotations.NotNull;
 import ru.tinkoff.invest.openapi.*;
-import ru.tinkoff.invest.openapi.models.streaming.StreamingEvent;
-
 import java.time.Duration;
-import java.util.function.Consumer;
+import java.util.concurrent.Executor;
 import java.util.logging.Logger;
 
 public class OkHttpOpenApiFactory extends OpenApiFactoryBase {
@@ -18,55 +16,40 @@ public class OkHttpOpenApiFactory extends OpenApiFactoryBase {
 
     @NotNull
     @Override
-    public OpenApi createOpenApiClient(@NotNull final Consumer<StreamingEvent> streamingEventCallback,
-                                       @NotNull final Consumer<Throwable> streamingErrorCallback) {
+    public OpenApi createOpenApiClient(@NotNull final Executor executor) {
         final OkHttpClient client = new OkHttpClient.Builder()
             .pingInterval(Duration.ofSeconds(5))
             .build();
         final String apiUrl = this.config.marketApiUrl;
 
-        final MarketContext marketContext = new MarketContextImpl(client, apiUrl, this.authToken, this.logger);
-        final OperationsContext operationsContext = new OperationsContextImpl(client, apiUrl, this.authToken, this.logger);
-        final OrdersContext ordersContext = new OrdersContextImpl(client, apiUrl, this.authToken, this.logger);
-        final PortfolioContext portfolioContext = new PortfolioContextImpl(client, apiUrl, this.authToken, this.logger);
-        final UserContext userContext = new UserContextImpl(client, apiUrl, this.authToken, this.logger);
-        final StreamingContext streamingContext = new StreamingContextImpl(client, this.config.streamingUrl, this.authToken, config.streamingParallelism, streamingEventCallback, streamingErrorCallback, this.logger);
-
-        return new OkHttpOpenApi(
-                marketContext,
-                operationsContext,
-                ordersContext,
-                portfolioContext,
-                userContext,
-                streamingContext
+        return OkHttpOpenApi.create(
+                client,
+                apiUrl,
+                config.streamingUrl,
+                config.streamingParallelism,
+                authToken,
+                executor,
+                logger
         );
     }
 
     @NotNull
     @Override
-    public SandboxOpenApi createSandboxOpenApiClient(@NotNull Consumer<StreamingEvent> streamingEventCallback,
-                                              @NotNull Consumer<Throwable> streamingErrorCallback) {
+    public SandboxOpenApi createSandboxOpenApiClient(@NotNull final Executor executor) {
         final OkHttpClient client = new OkHttpClient.Builder()
-                .pingInterval(Duration.ofSeconds(5))
-                .build();
+            .pingInterval(Duration.ofSeconds(5))
+            .build();
         final String apiUrl = this.config.sandboxApiUrl;
 
-        final MarketContext marketContext = new MarketContextImpl(client, apiUrl, this.authToken, this.logger);
-        final OperationsContext operationsContext = new OperationsContextImpl(client, apiUrl, this.authToken, this.logger);
-        final OrdersContext ordersContext = new OrdersContextImpl(client, apiUrl, this.authToken, this.logger);
-        final PortfolioContext portfolioContext = new PortfolioContextImpl(client, apiUrl, this.authToken, this.logger);
-        final UserContext userContext = new UserContextImpl(client, apiUrl, this.authToken, this.logger);
-        final StreamingContext streamingContext = new StreamingContextImpl(client, this.config.streamingUrl, this.authToken, config.streamingParallelism, streamingEventCallback, streamingErrorCallback, this.logger);
-        final SandboxContext sandboxContext = new SandboxContextImpl(client, apiUrl, this.authToken, this.logger);
-
-        return new OkHttpSandboxOpenApi(
-                marketContext,
-                operationsContext,
-                ordersContext,
-                portfolioContext,
-                userContext,
-                streamingContext,
-                sandboxContext
+        return OkHttpSandboxOpenApi.create(
+                client,
+                apiUrl,
+                config.streamingUrl,
+                config.streamingParallelism,
+                authToken,
+                executor,
+                logger
         );
     }
+
 }

--- a/sdk-java8/src/main/java/ru/tinkoff/invest/openapi/okhttp/OkHttpSandboxOpenApi.java
+++ b/sdk-java8/src/main/java/ru/tinkoff/invest/openapi/okhttp/OkHttpSandboxOpenApi.java
@@ -1,27 +1,62 @@
 package ru.tinkoff.invest.openapi.okhttp;
 
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+
 import org.jetbrains.annotations.NotNull;
+
+import okhttp3.OkHttpClient;
 import ru.tinkoff.invest.openapi.*;
 
 public class OkHttpSandboxOpenApi extends OkHttpOpenApi implements SandboxOpenApi {
 
     @NotNull
-    private final SandboxContext sandboxContext;
+    private final SandboxContextImpl sandboxContext;
 
-    OkHttpSandboxOpenApi(@NotNull final MarketContext marketContext,
-                         @NotNull final OperationsContext operationsContext,
-                         @NotNull final OrdersContext ordersContext,
-                         @NotNull final PortfolioContext portfolioContext,
-                         @NotNull final UserContext userContext,
-                         @NotNull final StreamingContext streamingContext,
-                         @NotNull final SandboxContext sandboxContext) {
-        super(marketContext, operationsContext, ordersContext, portfolioContext, userContext, streamingContext);
+    OkHttpSandboxOpenApi(@NotNull final OkHttpClient client,
+                         @NotNull final MarketContextImpl marketContext,
+                         @NotNull final OperationsContextImpl operationsContext,
+                         @NotNull final OrdersContextImpl ordersContext,
+                         @NotNull final PortfolioContextImpl portfolioContext,
+                         @NotNull final UserContextImpl userContext,
+                         @NotNull final StreamingContextImpl streamingContext,
+                         @NotNull final SandboxContextImpl sandboxContext) {
+        super(client, marketContext, operationsContext, ordersContext, portfolioContext, userContext, streamingContext);
         this.sandboxContext = sandboxContext;
+    }
+
+    public static OkHttpSandboxOpenApi create(
+        final OkHttpClient client,
+        final String apiUrl,
+        final String streamingUrl,
+        final int streamingParallelism,
+        final String authToken,
+        final Executor executor,
+        final Logger logger
+    ) {
+        final MarketContextImpl marketContext = new MarketContextImpl(client, apiUrl, authToken, logger);
+        final OperationsContextImpl operationsContext = new OperationsContextImpl(client, apiUrl, authToken, logger);
+        final OrdersContextImpl ordersContext = new OrdersContextImpl(client, apiUrl, authToken, logger);
+        final PortfolioContextImpl portfolioContext = new PortfolioContextImpl(client, apiUrl, authToken, logger);
+        final UserContextImpl userContext = new UserContextImpl(client, apiUrl, authToken, logger);
+        final StreamingContextImpl streamingContext = new StreamingContextImpl(client, streamingUrl, authToken, streamingParallelism, logger, executor);
+        final SandboxContextImpl sandboxContext = new SandboxContextImpl(client, apiUrl, authToken, logger);
+
+        return new OkHttpSandboxOpenApi(
+                client,
+                marketContext,
+                operationsContext,
+                ordersContext,
+                portfolioContext,
+                userContext,
+                streamingContext,
+                sandboxContext
+        );
     }
 
     @NotNull
     @Override
     public SandboxContext getSandboxContext() {
-        return sandboxContext;
+        return this.sandboxContext;
     }
 }


### PR DESCRIPTION
Теперь StreaminApiContext завязан на интерфейсе [Reactive Streams](https://github.com/reactive-streams/reactive-streams-jvm). Реализация на Java 8 имплементирует асинхронный вариант  `org.reactivestreams.Producer`. Асинхронность можно контролировать указанием нужного экземпляра `java.util.concurrent.Executor` при создании объекта `OpenApi`/`SandboxOpenApi`.
В примере показано использование новой реализации с применением `org.reactivestreams.example.unicast.AsyncSubscriber` в качестве имплементации `org.reactivestreams.Subscriber`.