### PR TITLE
Отмена уже отмененной заявки кладет клиент

### DIFF
--- a/core/src/main/java/ru/tinkoff/invest/openapi/exceptions/NotEnoughBalanceException.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/exceptions/NotEnoughBalanceException.java
@@ -18,6 +18,7 @@ public class NotEnoughBalanceException extends OpenApiException {
         super(message, code);
 
         final Matcher matchResult = currencyExtractionPattern.matcher(message);
+        matchResult.matches();
         this.currency = matchResult.group(matchResult.groupCount());
     }
 

--- a/core/src/main/java/ru/tinkoff/invest/openapi/exceptions/OrderAlreadyCancelledException.java
+++ b/core/src/main/java/ru/tinkoff/invest/openapi/exceptions/OrderAlreadyCancelledException.java
@@ -18,6 +18,7 @@ public class OrderAlreadyCancelledException extends OpenApiException {
         super(message, code);
 
         final Matcher matchResult = orderIdExtractionPattern.matcher(message);
+        matchResult.matches();
         this.orderId = matchResult.group(matchResult.groupCount());
     }
 


### PR DESCRIPTION
Минимальный код для воспроизведения проблемы:

```kotlin
    override suspend fun placeLimitBuy(
        ticker: Ticker,
        upToPrice: Double,
        volume: Long
    ): Order {
        val order = LimitOrder(
            volume.toInt(),
            Operation.Buy,
            upToPrice.toBigDecimal().setScale(2, RoundingMode.HALF_UP)
        )
        val result = api.ordersContext.placeLimitOrder(ticker.figi(tickersConfig).id, order, "").await()
        return Order(
            result.id,
            ticker,
            result.operation.toModel(),
            result.requestedLots.toLong(),
            result.executedLots.toLong(),
            upToPrice
        )
    }

    override suspend fun cancelOrder(id: String) {
        withTimeout(3000) {
            api.ordersContext.cancelOrder(id, "").await()
        }
    }


  val order = client.placeLimitBuy(Ticker("RIG"), 1.0, 1)
  delay(2000)
  client.cancelOrder(order.id)
  delay(2000)
  client.cancelOrder(order.id)
```

Вторая отмена заявки кладет клиент с исключением 
```
Exception in thread "OkHttp Dispatcher" java.lang.IllegalStateException: No match found
	at java.base/java.util.regex.Matcher.group(Matcher.java:645)
	at ru.tinkoff.invest.openapi.exceptions.OrderAlreadyCancelledException.<init>(OrderAlreadyCancelledException.java:21)
	at ru.tinkoff.invest.openapi.okhttp.OrdersContextImpl$6.onResponse(OrdersContextImpl.java:209)
	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:504)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

Любые последющие запросы через клиент будут неуспешны

```
Jul 07, 2020 11:00:31 AM ru.tinkoff.invest.openapi.okhttp.StreamingContextImpl$StreamingApiListener onFailure
SEVERE: Что-то произошло в Streaming API клиенте #2
java.io.EOFException
	at okio.RealBufferedSource.require(RealBufferedSource.kt:201)
	at okio.RealBufferedSource.readByte(RealBufferedSource.kt:210)
	at okhttp3.internal.ws.WebSocketReader.readHeader(WebSocketReader.kt:119)
	at okhttp3.internal.ws.WebSocketReader.processNextFrame(WebSocketReader.kt:102)
	at okhttp3.internal.ws.RealWebSocket.loopReader(RealWebSocket.kt:293)
	at okhttp3.internal.ws.RealWebSocket$connect$1.onResponse(RealWebSocket.kt:195)
	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:504)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

Судя по этому треду в СО https://stackoverflow.com/questions/5674268/no-match-found-when-using-matchers-group-method перед вызовом group, нужно сначала сделать вызов matches, что должно починить проблему