### PR TITLE
#49 Устранены проблемы с JitPack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin/
 target/
 
 gradle.properties
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Release](https://jitpack.io/v/User/Repo.svg?style=flat-square)]
+(https://jitpack.io/#User/Repo)
+
 # OpenAPI SDK для Java
 
 Данный проект представляет собой инструментарий на языке Java для работы с OpenAPI Тинькофф Инвестиции, который можно

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
JitPack использует по умолчанию JDK версии 8. Необходимо было задать версию 11.